### PR TITLE
deprecate Pixels.relatedTo

### DIFF
--- a/src/main/resources/mappings/acquisition.ome.xml
+++ b/src/main/resources/mappings/acquisition.ome.xml
@@ -55,6 +55,7 @@
 		<properties>
 			<!-- Acquisition Context 1 -->
 			<manyone name="image" type="ome.model.core.Image" ordered="true"/>
+			<!-- Warning: relatedTo is DEPRECATED and may be removed in OMERO 6.0. -->
 			<optional name="relatedTo" type="ome.model.core.Pixels"/>
 			<!-- Note: relatedTo is not used in model-->
 			<required name="pixelsType" type="ome.model.enums.PixelsType"/>


### PR DESCRIPTION
Related pixels are more confusing than helpful and this is not the approach we want to adopt for image-image linking.