### PR TITLE
Update Hibernate DTD URL to current recommendation.

### DIFF
--- a/src/main/resources/mock_filters.hbm.xml
+++ b/src/main/resources/mock_filters.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE hibernate-mapping PUBLIC
         "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd" >
+        "http://hibernate.org/dtd/hibernate-mapping-3.0.dtd" >
 
 <hibernate-mapping>
     <filter-def name="AllGroupsSecurityFilter" condition="1=1"/>

--- a/src/main/resources/templates/cfg.vm
+++ b/src/main/resources/templates/cfg.vm
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-configuration PUBLIC
 		"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-		"http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd">
+		"http://hibernate.org/dtd/hibernate-configuration-3.0.dtd">
 <hibernate-configuration>
     <session-factory>
 #foreach($type in $types)


### PR DESCRIPTION
Should not cause any regressions.

Supports https://github.com/ome/omero-blitz/pull/28.