### PR TITLE
Javadoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
+dist: xenial
 language: java
+jdk:
+  - oraclejdk11
+  - openjdk8
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -13,3 +17,4 @@ install:
 script:
   - ./gradlew publishToMavenLocal
   - ./gradlew test
+  - ./gradlew javadoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 language: java
 jdk:
-  - oraclejdk11
+  - openjdk11
   - openjdk8
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/src/main/java/ome/conditions/ApiUsageException.java
+++ b/src/main/java/ome/conditions/ApiUsageException.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.ApiUsageException
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -13,8 +11,8 @@ package ome.conditions;
  * broken may be declaratively checked with annotations and an interceptor or at
  * run-time with simple assertions.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/conditions/InternalException.java
+++ b/src/main/java/ome/conditions/InternalException.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.RootException
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -10,8 +8,8 @@ package ome.conditions;
  * Catchall for unknown server exceptions. This most likely represents a bug in
  * the server-code and should be reported to the Omero team.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/conditions/OptimisticLockException.java
+++ b/src/main/java/ome/conditions/OptimisticLockException.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.ptimisticException
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -11,8 +9,8 @@ package ome.conditions;
  * specifically a query of the form : "&lt;action&gt; where id = ? and version = ?"
  * applied to no rows.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/conditions/OverUsageException.java
+++ b/src/main/java/ome/conditions/OverUsageException.java
@@ -9,15 +9,13 @@ package ome.conditions;
 /**
  * More specific {@link ome.conditions.ApiUsageException ApiUsageException}, in
  * that the current use of the OMERO API could overwhelm the server and has been blocked.
- * 
- * <p>
+ *
  * Examples include:
  * <ul>
  * <li>Creating too many sessions in too short a period of time</li>
- * <li>Opening too many stateful services
+ * <li>Opening too many stateful services</li>
  * <li>Requesting too many database objects in one call</li>
  * </ul>
- * </p>
  * 
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.0

--- a/src/main/java/ome/conditions/ResourceError.java
+++ b/src/main/java/ome/conditions/ResourceError.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.ResourceError
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -10,8 +8,8 @@ package ome.conditions;
  * Represents a incorrectible/unforseeable event within the server that lead to
  * a failure of a process.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 2.5
  * @since 2.5
  */

--- a/src/main/java/ome/conditions/RootException.java
+++ b/src/main/java/ome/conditions/RootException.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.RootException
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -10,8 +8,8 @@ package ome.conditions;
  * abstract superclass of all Omero exceptions. Only subclasses of this type
  * will be thrown by the server.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 2.5
  * @since 2.5
  */

--- a/src/main/java/ome/conditions/SecurityViolation.java
+++ b/src/main/java/ome/conditions/SecurityViolation.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.SecurityViolation
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -9,8 +7,8 @@ package ome.conditions;
 /**
  * User does not have permissions to perform given action.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 2.5
  * @since 2.5
  */

--- a/src/main/java/ome/conditions/ValidationException.java
+++ b/src/main/java/ome/conditions/ValidationException.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.ValidationException
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -10,17 +8,15 @@ package ome.conditions;
  * More specific {@link ome.conditions.ApiUsageException ApiUsageException}, in
  * that the specification of your data as outlined in the OME specification is
  * incorrect.
- * 
- * <p>
+ *
  * Examples include:
  * <ul>
  * <li>a {@link ome.model.containers.Project Project} name with invalid
  * characters</li>
  * </ul>
- * </p>
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/conditions/acl/ACLCreateViolation.java
+++ b/src/main/java/ome/conditions/acl/ACLCreateViolation.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.ACLCreateViolation
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -9,8 +7,8 @@ package ome.conditions.acl;
 /**
  * User does not have permissions to perform given action.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 2.5
  * @since 2.5
  */

--- a/src/main/java/ome/conditions/acl/ACLDeleteViolation.java
+++ b/src/main/java/ome/conditions/acl/ACLDeleteViolation.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.ACLDeleteViolation
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -9,8 +7,8 @@ package ome.conditions.acl;
 /**
  * User does not have permissions to perform given action.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 2.5
  * @since 2.5
  */

--- a/src/main/java/ome/conditions/acl/ACLLoadViolation.java
+++ b/src/main/java/ome/conditions/acl/ACLLoadViolation.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.ACLLoadViolation
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -9,8 +7,8 @@ package ome.conditions.acl;
 /**
  * User does not have permissions to perform given action.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 2.5
  * @since 2.5
  */

--- a/src/main/java/ome/conditions/acl/ACLUpdateViolation.java
+++ b/src/main/java/ome/conditions/acl/ACLUpdateViolation.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.ACLUpdateViolation
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -9,8 +7,8 @@ package ome.conditions.acl;
 /**
  * User does not have permissions to perform given action.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 2.5
  * @since 2.5
  */

--- a/src/main/java/ome/conditions/acl/ACLViolation.java
+++ b/src/main/java/ome/conditions/acl/ACLViolation.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.ACLViolation
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -12,8 +10,8 @@ import ome.model.internal.Permissions;
  * User has attempted an action which is not permitted by the
  * {@link Permissions} of a given instance.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 2.5
  * @since 2.5
  */

--- a/src/main/java/ome/conditions/acl/CollectedACLViolations.java
+++ b/src/main/java/ome/conditions/acl/CollectedACLViolations.java
@@ -1,6 +1,4 @@
 /*
- * ome.conditions.CollectedACLViolations
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -15,8 +13,8 @@ import ome.model.internal.Permissions;
  * User has attempted an action which is not permitted by the
  * {@link Permissions} of a given instance.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 2.5
  * @since 2.5
  */

--- a/src/main/java/ome/model/IDetails.java
+++ b/src/main/java/ome/model/IDetails.java
@@ -1,6 +1,4 @@
 /*
- * ome.model.IDetails
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -13,8 +11,8 @@ import ome.model.meta.Experimenter;
 /**
  * simple interface for {@link ome.model.internal.Details}; currently unused.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/model/IEnum.java
+++ b/src/main/java/ome/model/IEnum.java
@@ -1,6 +1,4 @@
 /*
- * ome.model.IEnum
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -11,8 +9,8 @@ package ome.model;
  * provide access to the single value associated with this instance (See
  * {@link #getValue()})
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  * @author josh

--- a/src/main/java/ome/model/ILink.java
+++ b/src/main/java/ome/model/ILink.java
@@ -1,6 +1,4 @@
 /*
- * ome.model.ILink
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -11,8 +9,8 @@ package ome.model;
  * represents a many-to-many relationship between two classes that take part in
  * a containment relationship.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  * @see ome.model.core.Image

--- a/src/main/java/ome/model/IMutable.java
+++ b/src/main/java/ome/model/IMutable.java
@@ -1,6 +1,4 @@
 /*
- * ome.model.ILink
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -12,8 +10,8 @@ package ome.model;
  * but without a version passed to the backend is considered an error, since
  * some backends will silently create a new object in the database.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  * @author josh

--- a/src/main/java/ome/model/IObject.java
+++ b/src/main/java/ome/model/IObject.java
@@ -1,6 +1,4 @@
 /*
- * ome.model.IObject
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -21,8 +19,8 @@ import ome.util.Validation;
  * {@link ome.model.internal.Details} get saved to the DB, but only embedded in
  * other entites.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  * @author josh

--- a/src/main/java/ome/model/ModelBased.java
+++ b/src/main/java/ome/model/ModelBased.java
@@ -17,8 +17,8 @@ import ome.util.ReverseModelMapper;
  * In reverse mapping, however, the burden of mapping can be placed on the
  * foreign (target) objects, which simplifies the process.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @since 2.5
  * @see ome.util.ModelMapper
  * @see ome.util.ReverseModelMapper

--- a/src/main/java/ome/model/internal/Details.java
+++ b/src/main/java/ome/model/internal/Details.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -30,8 +28,8 @@ import ome.util.Filterable;
  * treatment through the Omero system, especially during
  * {@code ome.api.IUpdate} update.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  * @see "ome.api.IUpdate"

--- a/src/main/java/ome/model/internal/GraphHolder.java
+++ b/src/main/java/ome/model/internal/GraphHolder.java
@@ -1,6 +1,4 @@
 /*
- * ome.model.internal.GraphHolder
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -17,8 +15,8 @@ import ome.model.IObject;
  * and {@link GraphHolder#setToken(Token, Token)} are final so that subclasses
  * cannot intercept tokens.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  * @author josh

--- a/src/main/java/ome/model/internal/Permissions.java
+++ b/src/main/java/ome/model/internal/Permissions.java
@@ -45,8 +45,7 @@ import ome.conditions.ApiUsageException;
  * grant/revoke/isSet logic will remain the same.
  * </p>
  * 
- * @see <a
- *      href="https://trac.openmicroscopy.org/ome/ticket/180">ticket:180</a>
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/180">ticket:180</a>
  */
 public class Permissions implements Serializable {
 

--- a/src/main/java/ome/model/internal/Token.java
+++ b/src/main/java/ome/model/internal/Token.java
@@ -1,6 +1,4 @@
 /*
- * ome.model.internal.Token
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -9,8 +7,8 @@ package ome.model.internal;
 /**
  * authorization token to allow/revoke certain privileges.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  * @author josh

--- a/src/main/java/ome/parameters/Filter.java
+++ b/src/main/java/ome/parameters/Filter.java
@@ -1,6 +1,4 @@
 /*
- * ome.parameters.Filter
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -14,8 +12,8 @@ import java.sql.Timestamp;
  * parameter to generally reduce the size of a query result set.
  * 
  * @author <br>
- *         Josh Moore&nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
+ *         Josh Moore&nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0-M2
  */

--- a/src/main/java/ome/parameters/Parameters.java
+++ b/src/main/java/ome/parameters/Parameters.java
@@ -30,8 +30,8 @@ import ome.conditions.ApiUsageException;
  * the form ":id".
  * 
  * @author <br>
- *         Josh Moore&nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
+ *         Josh Moore&nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0-M2
  */

--- a/src/main/java/ome/parameters/Period.java
+++ b/src/main/java/ome/parameters/Period.java
@@ -1,6 +1,4 @@
 /*
- * ome.parameters.Page
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -17,8 +15,8 @@ import ome.conditions.ApiUsageException;
  * List-valued result set.
  * 
  * @author <br>
- *         Josh Moore&nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
+ *         Josh Moore&nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0-M2
  */

--- a/src/main/java/ome/parameters/QueryParameter.java
+++ b/src/main/java/ome/parameters/QueryParameter.java
@@ -1,6 +1,4 @@
 /*
- * ome.parameters.QueryParameter
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -18,8 +16,8 @@ import ome.conditions.ApiUsageException;
  * arbitrary query parameter used by {@code ome.api.IQuery}.
  * 
  * @author <br>
- *         Josh Moore&nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
+ *         Josh Moore&nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0-M2
  */

--- a/src/main/java/ome/util/CBlock.java
+++ b/src/main/java/ome/util/CBlock.java
@@ -1,6 +1,4 @@
 /*
- * ome.util.CBlock
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -17,8 +15,8 @@ import ome.model.core.Image;
  * valued fields on model objects have a method that will scan the collection
  * and apply the block of code. For example, {@link Image#collectPixels(CBlock)}
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/util/ContextFilter.java
+++ b/src/main/java/ome/util/ContextFilter.java
@@ -36,15 +36,16 @@ import org.slf4j.LoggerFactory;
  * Note: This class is not thread-safe.
  *
  * template method to filter domain objects. The standard idiom is:
- * <code>
+ * <pre>
+ * {@code
  *  if (m != null && hasntSeen(m)){
  *      enter(m); // Provides context
  *      addSeen(m); // Prevents looping
  *      m.acceptFilter(this); // Visits all fields
  *      exit(m); // Remove from context
  *  }
- *
- * </code>
+ *}
+ * </pre>
  *
  *
  * Implementation notes: - nulls are already "seen"

--- a/src/main/java/ome/util/ContextFilter.java
+++ b/src/main/java/ome/util/ContextFilter.java
@@ -35,7 +35,8 @@ import org.slf4j.LoggerFactory;
  *
  * Note: This class is not thread-safe.
  *
- * template method to filter domain objects. The standard idiom is: <code>
+ * template method to filter domain objects. The standard idiom is:
+ * <code>
  *  if (m != null && hasntSeen(m)){
  *      enter(m); // Provides context
  *      addSeen(m); // Prevents looping

--- a/src/main/java/ome/util/EmptyIterator.java
+++ b/src/main/java/ome/util/EmptyIterator.java
@@ -1,6 +1,4 @@
 /*
- * ome.util.ContextFilter
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -13,8 +11,8 @@ import java.util.NoSuchElementException;
 /**
  * utility iterator which does nothing as quickly as possible.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/util/Filter.java
+++ b/src/main/java/ome/util/Filter.java
@@ -1,6 +1,4 @@
 /*
- * ome.util.Filter
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -16,8 +14,8 @@ import java.util.Map;
  * altered visitor pattern. model only calls visit on each of its fields. the
  * rest of the navigation is done in visitor.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 1.0
  * @since 1.0
  */

--- a/src/main/java/ome/util/Filterable.java
+++ b/src/main/java/ome/util/Filterable.java
@@ -1,6 +1,4 @@
 /*
- * ome.util.Filterable
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -13,8 +11,8 @@ package ome.util;
  * altered visitor pattern. model only calls visit on each of its fields. the
  * rest of the navigation is done in visitor.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 1.0
  * @since 1.0
  */

--- a/src/main/java/ome/util/IdBlock.java
+++ b/src/main/java/ome/util/IdBlock.java
@@ -1,6 +1,4 @@
 /*
- * ome.util.IdBlock
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -13,8 +11,8 @@ import ome.model.IObject;
  * {@link ome.util.CBlock CBlock} implementation which collects ids from
  * {@link ome.model.IObject IObjects}
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/util/ImageUtil.java
+++ b/src/main/java/ome/util/ImageUtil.java
@@ -17,8 +17,8 @@ import java.awt.image.WritableRaster;
 /**
  * Provides helper methods for performing various things on image data.
  * 
- * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
+ * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/util/LSID.java
+++ b/src/main/java/ome/util/LSID.java
@@ -15,7 +15,7 @@ import java.util.Locale;
 /**
  * This class represents an LSID as used by the OME-XML data model.
  * 
- * @author Chris Allan <callan at blackcat dot ca>
+ * @author Chris Allan callan at blackcat dot ca
  *
  */
 public class LSID

--- a/src/main/java/ome/util/ModelMapper.java
+++ b/src/main/java/ome/util/ModelMapper.java
@@ -1,6 +1,4 @@
 /*
- * ome.util.ModelMapper
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -29,8 +27,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 1.0
  * @since 1.0
  */

--- a/src/main/java/ome/util/PixelData.java
+++ b/src/main/java/ome/util/PixelData.java
@@ -1,6 +1,4 @@
 /*
- * ome.util.PixelData
- *
  *   Copyright 2007-2014 Glencoe Software Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -19,8 +17,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Represents a block of pixel data.
  *
- * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:chris@glencoesoftware.com">chris@glencoesoftware.com</a>
+ * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:chris@glencoesoftware.com">chris@glencoesoftware.com</a>
  * @author m.t.b.carroll@dundee.ac.uk
  * @version $Revision$
  * @since 3.0

--- a/src/main/java/ome/util/ReverseModelMapper.java
+++ b/src/main/java/ome/util/ReverseModelMapper.java
@@ -1,6 +1,4 @@
 /*
- * ome.util.ReverseModelMapper
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -12,11 +10,11 @@ import java.util.Collection;
 import ome.model.ModelBased;
 
 /**
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @since 1.0
  */
-public interface ReverseModelMapper { // extends ContextFilter {
+public interface ReverseModelMapper {
 
     public Filterable reverse(ModelBased source);
     public Collection reverse(Collection source);

--- a/src/main/java/ome/util/Utils.java
+++ b/src/main/java/ome/util/Utils.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2006-2014 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -19,8 +17,8 @@ import ome.model.internal.Permissions;
 /**
  * various tools needed throughout Omero.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 1.0
  * @since 1.0
  * TODO Grinder issues should be moved to test component to reduce deps.

--- a/src/main/java/ome/util/Validation.java
+++ b/src/main/java/ome/util/Validation.java
@@ -1,6 +1,4 @@
 /*
- * ome.util.Validation
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -16,8 +14,8 @@ import org.slf4j.LoggerFactory;
 /**
  * collector for Model-validation status.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 1.0
  * @since 1.0
  */

--- a/src/main/java/ome/util/Validator.java
+++ b/src/main/java/ome/util/Validator.java
@@ -1,6 +1,4 @@
 /*
- * ome.util.Validator
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -18,8 +16,8 @@ import ome.model.core.Pixels;
 /**
  * tests of model objects for validity.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 1.0
  * @since 1.0
  */


### PR DESCRIPTION
fix javadoc warnings
In order to see if some warnings remain, you will need to use Java version > 1.8 (tested with Java 11)
Currently no warnings are returned if Java 1.8 is used
To check run ``gradle javadoc``