### PR TITLE
Reduce the number of declaration for Bio-Formats dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,9 @@ dependencies {
     // Our libraries
     api("ome:formats-gpl:6.0.1") {
         exclude group: "org.perf4j", module: "perf4j"
+        exclude group: "com.google.guava", module: "guava"
     }
+    api("com.google.guava:guava:27.1-jre")
 
     // Necessary since formats-bsd has version 0.9.13. This should be removed
     // when fixed in B-F

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     api("org.hibernate:hibernate-search:3.4.2.Final")
 
     // Our libraries
-    api("ome:formats-gpl:5.9.2") {
+    api("ome:formats-gpl:6.0.1") {
         exclude group: "org.perf4j", module: "perf4j"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,9 @@ dependencies {
     api("org.hibernate:hibernate-search:3.4.2.Final")
 
     // Our libraries
-    api("org.openmicroscopy:ome-xml:5.6.3")
-    api("ome:formats-bsd:5.9.2") {
+    api("ome:formats-gpl:5.9.2") {
         exclude group: "org.perf4j", module: "perf4j"
     }
-    api("ome:formats-gpl:5.9.2")
 
     // Necessary since formats-bsd has version 0.9.13. This should be removed
     // when fixed in B-F
@@ -42,7 +40,6 @@ dependencies {
     // Unidata
     api("edu.ucar:bufr:3.0")
     api("edu.ucar:udunits:4.5.5")
-    api("edu.ucar:netcdf:4.3.22")
 }
 
 test {


### PR DESCRIPTION
formats-bsd, netcdf and ome-xml are transitive dependencies of formats-gpl. This should reduce the number of places to update when bumping Bio-Formats. The udunits version was not removed as it is different from the one declared by edu.ucar:netcdf:4.3.22

This is not strictly necessary for the upcoming Bio-Formats work but mostly opening the discussion about reducing the declaration of our dependencies. Importantly these changes assume we do not want to override transitive dependencies individually.

If the statement above is not true i.e. we foresee a case for bumping `ome-xml` totally independently of `formats-{bsd,gpl}` then the current layout should be preserved and this PR can be closed. Note in that case, I am unclear whether the declaration order matters for the dependency resolution.