### PR TITLE
Convert Unicode in properties file to non-literal.

### DIFF
--- a/src/main/resources/ome/util/actions/psql.properties
+++ b/src/main/resources/ome/util/actions/psql.properties
@@ -1,5 +1,5 @@
 sql_action.active_session=select count(id) from session s where s.closed is null and s.uuid = ?
-sql_action.check_units=SELECT CAST('Å' AS UnitsLength)
+sql_action.check_units=SELECT CAST(CHR(197) AS UnitsLength)
 sql_action.curr_val=select next_val from seq_table where sequence_name = ?
 sql_action.db_version=select currentversion, currentpatch from dbpatch order by id desc limit 1
 sql_action.get_pixels_name_path_repo=select name, path, repo from pixels where id = ?


### PR DESCRIPTION
Works around the character corruption recorded by https://trello.com/c/ymCboXZk/135-character-encoding-in-properties.