### PR TITLE
Exclude edu.ucar:netcdf transitive dependency from bufr dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,9 @@ dependencies {
     api("org.perf4j:perf4j:0.9.16")
 
     // Unidata
-    api("edu.ucar:bufr:3.0")
+    api("edu.ucar:bufr:3.0"){
+        exclude group: "edu.ucar", module: "netcdf"
+    }
     api("edu.ucar:udunits:4.5.5")
 }
 


### PR DESCRIPTION
This exclusion is mandatory so that the components work with the netcdf upgrade.

See https://github.com/openmicroscopy/bioformats/pull/3358#issuecomment-487896563