### PR TITLE
Build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,10 +81,6 @@ dsl {
     }
 }
 
-clean {
-    delete dsl.outputDir
-}
-
 processResources {
     with copySpec {
         from 'src/main/resources'

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ test {
 dsl {
     database databaseType
 
+    outputDir file("build/${databaseType}")
+
     multiFile {
         java {
             template "object.vm"


### PR DESCRIPTION
Do not use the default setup so that nothing is generated under ``src``

To test:

* if you have previously done a build, make sure that there is no folder ``psql`` under ``src``. Delete it if there is one
* run ``gradle build``, check that ``psql`` is created under ``build`` and not ``src``