### PR TITLE
Adjust combined_fields annotations for search.

### DIFF
--- a/src/main/resources/templates/object.vm
+++ b/src/main/resources/templates/object.vm
@@ -1471,9 +1471,7 @@ implements java.io.Serializable, IObject
     @org.hibernate.search.annotations.DateBridge(
         resolution=org.hibernate.search.annotations.Resolution.MINUTE)
     @org.hibernate.search.annotations.Fields({
-        @org.hibernate.search.annotations.Field(index = org.hibernate.search.annotations.Index.UN_TOKENIZED),
-        @org.hibernate.search.annotations.Field(index = org.hibernate.search.annotations.Index.UN_TOKENIZED,
-            name = "combined_fields")
+        @org.hibernate.search.annotations.Field(index = org.hibernate.search.annotations.Index.UN_TOKENIZED)
     })
 #else
     // Not indexed

--- a/src/main/resources/templates/object.vm
+++ b/src/main/resources/templates/object.vm
@@ -1462,7 +1462,9 @@ implements java.io.Serializable, IObject
 #elseif($prop.type == "java.lang.Integer" || $prop.type == "java.lang.Long" || $prop.type == "java.lang.Double" || $prop.type == "java.lang.Float")
     @org.hibernate.search.annotations.Fields({
         @org.hibernate.search.annotations.Field(index = org.hibernate.search.annotations.Index.UN_TOKENIZED),
-        @org.hibernate.search.annotations.Field(index = org.hibernate.search.annotations.Index.UN_TOKENIZED,
+        @org.hibernate.search.annotations.Field(index = org.hibernate.search.annotations.Index.TOKENIZED,
+                                                analyzer = @org.hibernate.search.annotations.Analyzer(
+                                                    impl = ome.services.fulltext.ConfiguredAnalyzer.class),
             name="combined_fields")
     })
 #elseif($prop.type == "java.sql.Timestamp")


### PR DESCRIPTION
My having speculated that having a mix of tokenized and untokenized values for the same field is causing search indexing unreliability this PR,

- tokenizes numeric values in `combined_fields`
- does not include timestamps in `combined_fields`.