### PR TITLE
Use DTD from JAR for validating Hibernate configuration.

### DIFF
--- a/src/main/resources/templates/cfg.vm
+++ b/src/main/resources/templates/cfg.vm
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-configuration PUBLIC
-		"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-		"http://hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+<!DOCTYPE hibernate-configuration SYSTEM
+		"classpath://org/hibernate/hibernate-configuration-3.0.dtd">
 <hibernate-configuration>
     <session-factory>
 #foreach($type in $types)


### PR DESCRIPTION
Fixes https://github.com/openmicroscopy/openmicroscopy/issues/6041 by reading the DTD from the JAR instead of from the Internet when validating the Hibernate configuration on server startup.