### PR TITLE
fix punctuation in Details.toString()

### DIFF
--- a/src/main/java/ome/model/internal/Details.java
+++ b/src/main/java/ome/model/internal/Details.java
@@ -346,12 +346,12 @@ public abstract class Details implements Filterable, Serializable {
     }
 
     public void toString(StringBuilder sb) {
-        sb.append(";perm=");
+        sb.append("perm=");
         sb.append(_perms == null ? null : _perms.toString());
         if (_externalInfo != null) {
             sb.append(";external=" + _externalInfo.getId());
         }
-        sb.append("user=");
+        sb.append(";user=");
         sb.append(_owner == null ? null : _owner.getId());
         sb.append(";group=");
         sb.append(_group == null ? null : _group.getId());


### PR DESCRIPTION
Intercalates semi-colons between the reported property values for representing the state of the server's internal `Details` instances. For example,

before:
`Details:{;perm=rwrw--user=803;group=804;create=null;update=null}`
after:
`Details:{perm=rwrw--;user=803;group=804;create=null;update=null}`