### PR TITLE
Handle nulls on findLink-style model methods (fix #65)

### DIFF
--- a/src/main/resources/templates/object.vm
+++ b/src/main/resources/templates/object.vm
@@ -1228,7 +1228,8 @@ implements java.io.Serializable, IObject
         final java.util.Set<${LinkType}> result = new java.util.HashSet<${LinkType}>();
         while ( it.hasNext() ) {
             ${LinkType} link = it.next();
-            if ( link.${other}() == target ) {
+            // null most likely means an ordered set index is missing
+            if ( link != null && link.${other}() == target ) {
                 result.add( link );
             }
         }


### PR DESCRIPTION
For non-managed objects, a null could have been purposefully stored
in the set. For managed objects, an ordered index can be missing from
the database in which case a null will be placed in the list. Either
way throwing a NullPointerException isn't useful, since an empty result
expresses the same fact: the target link is not present.

 - May require manipulating the database to reproduce the original issue.
 - Other tests should remain green.