### PR TITLE
Add `omero.pixeldata.max_projection_bytes` to dependency stack

### DIFF
--- a/src/main/resources/omero-model.properties
+++ b/src/main/resources/omero-model.properties
@@ -181,3 +181,8 @@ omero.pixeldata.max_plane_width=3192
 # These values will be ignored for floating or double pixel
 # data types where no pyramid will be generated.
 omero.pixeldata.max_plane_height=3192
+
+# Specifies the maximum number of bytes the server will
+# allow to be projected in real time with the rendering
+# engine.
+omero.pixeldata.max_projection_bytes=268435456


### PR DESCRIPTION
Further to discussion with @jburel on ome/omero-web#115, adding the future property to the very bottom of the dependency stack for consumption within omero-renderer, omero-server, etc. Will be used by ome/omero-common#22.