### PR TITLE
More thoroughly clean up current admin privileges table.

### DIFF
--- a/src/main/resources/ome/util/actions/psql.properties
+++ b/src/main/resources/ome/util/actions/psql.properties
@@ -9,7 +9,7 @@ sql_action.next_session=select ome_nextval('seq_session'::text)
 sql_action.next_val=select ome_nextval(?,?)
 sql_action.now=select now()
 sql_action.old_privileges_delete=DELETE FROM _current_admin_privileges WHERE transaction = ?
-sql_action.old_privileges_select=SELECT DISTINCT transaction FROM _current_admin_privileges WHERE transaction < txid_snapshot_xmin(txid_current_snapshot())
+sql_action.old_privileges_select=SELECT DISTINCT transaction FROM _current_admin_privileges WHERE transaction NOT IN (SELECT DISTINCT backend_xid FROM pg_stat_activity)
 sql_action.curr_privileges_delete=DELETE FROM _current_admin_privileges WHERE transaction = txid_current()
 sql_action.curr_privileges_insert=INSERT INTO _current_admin_privileges (transaction, privilege) VALUES (txid_current(), ?)
 sql_action.session_id=SELECT id FROM session WHERE uuid = ?


### PR DESCRIPTION
Uses metadata introduced in PostgreSQL 9.4 to more aggressively trim the `_current_admin_privileges` table. It *must* include the rows pertaining to the currently active transactions but, otherwise, the smaller the table, the faster the checks.