### PR TITLE
Prepare changelog for releasing OMERO 5.6.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+5.6.2 (September 2020)
+----------------------
+
+- New properties to configure JDBC ([#60](https://github.com/ome/omero-model/pull/60))
+
 5.6.1 (July 2020)
 -----------------
 


### PR DESCRIPTION
Update the changelog in preparation for releasing OMERO 5.6.3.

Stated version is that to which I propose naming the tag.