### PR TITLE
Link to quartz-scheduler CronExpression.htm

### DIFF
--- a/src/main/resources/omero-model.properties
+++ b/src/main/resources/omero-model.properties
@@ -102,9 +102,8 @@ omero.db.url=jdbc:postgresql://${omero.db.host}:${omero.db.port}/${omero.db.name
 # .. |cron| replace::
 #   Cron Format: seconds minutes hours day-of-month month day-of-week year
 #   (optional). For example, "0,30 * * * * ?" is equivalent to running every
-#   30 seconds. For more information download the latest *1.x version* of
-#   the `Quartz Job Scheduler`_ and review
-#   :file:`docs/api/org/quartz/CronExpression.html` within the distribution.
+#   30 seconds. See
+#   https://www.quartz-scheduler.org/api/1.8.6/org/quartz/CronExpression.html
 #
 # .. _Quartz Job Scheduler:
 #   https://www.quartz-scheduler.org/downloads/


### PR DESCRIPTION
Replaces `For more information download the latest 1.x version of the Quartz Job Scheduler and review docs/api/org/quartz/CronExpression.html within the distribution.` with a link to the web page.

Current page: https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/config.html#omero-search-cron