### PR TITLE
Bump org.openmicroscopy.project to version 5.5.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java-library"
-    id "org.openmicroscopy.project" version "5.5.3"
+    id "org.openmicroscopy.project" version "5.5.4"
     id "org.openmicroscopy.dsl" version "5.5.2"
 }
 


### PR DESCRIPTION
Hopefully this should solve the issue of the multiple publications
affecting both the SNAPSHOT and release versions