### PR TITLE
Bump Bio-Formats to 8.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     api("org.hibernate:hibernate-search:3.4.2.Final")
 
     // Our libraries
-    api("ome:formats-gpl:7.3.1")
+    api("ome:formats-gpl:8.0.0")
 
     // Unidata
     api("edu.ucar:bufr:3.0"){

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     api("org.hibernate:hibernate-search:3.4.2.Final")
 
     // Our libraries
-    api("ome:formats-gpl:8.0.0")
+    api("ome:formats-gpl:8.0.1")
 
     // Unidata
     api("edu.ucar:bufr:3.0"){


### PR DESCRIPTION
Replacement from #105 

Bumps the version of Bio-Formats used in OMERO to the latest 8.0.1 release. The announcements for last two releases can be found in https://www.openmicroscopy.org/2024/10/24/bio-formats-8-0-0.html https://www.openmicroscopy.org/2024/11/14/bio-formats-8-0-1.html