### PR TITLE
Specify Java target using release flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ Like any Java project, include the jar into your classpath.
 
 The compilation, testing, launch, and delivery of the application are
 automated by means of a Gradle (https://gradle.org/) build file.
-In order to perform a build, all you need is
-a JDK -- version 1.8 or later.
-Clone this GitHub repository `git clone https://github.com/ome/omero-model.git`.
+
+In order to perform a build, you need JDK 11 and Gradle 6.x installed. Clone
+this GitHub repository:
+
+    git clone https://github.com/ome/omero-model
+
 Go to the directory and enter:
 
-  gradle build
+    gradle build
 
 This will compile, build, test and create a distribution bundle.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java-library"
-    id "org.openmicroscopy.project" version "5.7.0"
-    id "org.openmicroscopy.dsl" version "5.5.2"
+    id "org.openmicroscopy.project" version "5.7.1"
+    id "org.openmicroscopy.dsl" version "5.5.3"
 }
 
 group = "org.openmicroscopy"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java-library"
     id "org.openmicroscopy.project" version "5.7.2"
-    id "org.openmicroscopy.dsl" version "5.5.3"
+    id "org.openmicroscopy.dsl" version "5.5.4"
 }
 
 group = "org.openmicroscopy"

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,8 @@ repositories {
     mavenCentral()
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+compileJava {
+    options.release = 8
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java-library"
-    id "org.openmicroscopy.project" version "5.7.1"
+    id "org.openmicroscopy.project" version "5.7.2"
     id "org.openmicroscopy.dsl" version "5.5.3"
 }
 


### PR DESCRIPTION
See https://docs.gradle.org/6.8/userguide/building_java_projects.html#sec:java_cross_compilation, the `sourceCompatibility` and `targetCompatibility` are legacy options to compile the Java bytecode to be compatible with a specific Java version.

Since the build system now requires JDK11, it is possible to take advantage of the Java release flag to produce binaries that are byte-compatible with Java 8. In addition, this PR update the build requirements from the README.

