### PR TITLE
Exclude dom4j:dom4j and declare dependency on org.dom4j:dom4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,13 @@ dependencies {
     api("org.springframework:spring-orm:4.3.30.RELEASE")
     api("org.springframework:spring-context:4.3.30.RELEASE")
     api("org.springframework:spring-context-support:4.3.30.RELEASE")
-    api("org.hibernate:hibernate-core:3.6.10.Final")
-    api("org.hibernate:hibernate-search:3.4.2.Final")
+    api("org.hibernate:hibernate-core:3.6.10.Final"){
+        exclude group: "dom4j", module: "dom4j"
+    }
+    api("org.hibernate:hibernate-search:3.4.2.Final"){
+        exclude group: "dom4j", module: "dom4j"
+    }
+    api("org.dom4j:dom4j:2.1.4")
 
     // Our libraries
     api("ome:formats-gpl:8.1.1")

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,9 @@ dependencies {
     testImplementation("org.testng:testng:7.5")
 
     // Needs updating to later versions
-    api("org.springframework:spring-orm:4.3.14.RELEASE")
-    api("org.springframework:spring-context:4.3.14.RELEASE")
-    api("org.springframework:spring-context-support:4.3.22.RELEASE")
+    api("org.springframework:spring-orm:4.3.30.RELEASE")
+    api("org.springframework:spring-context:4.3.30.RELEASE")
+    api("org.springframework:spring-context-support:4.3.30.RELEASE")
     api("org.hibernate:hibernate-core:3.6.10.Final")
     api("org.hibernate:hibernate-search:3.4.2.Final")
 


### PR DESCRIPTION
Hibernate 3 (and Hibernate 4) both depend on dom4j 1.x which latest releases have known CVEs which are flagged by package analyzers. This manually excludes dom4:dom4j from the transitive dependencies of hibernate-core and declare org.dom4j:dom4j. Once Hibernate is upgraded to a recent version this exclusion can be removed.

Update: rebased on top of #115 for integration in the nightly CI builds due to the conflicts when merging both branches