### PR TITLE
Remove bufr and udunits dependencies from omero-model

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,11 +37,6 @@ dependencies {
     // Our libraries
     api("ome:formats-gpl:8.1.1")
 
-    // Unidata
-    api("edu.ucar:bufr:3.0"){
-        exclude group: "edu.ucar", module: "netcdf"
-    }
-    api("edu.ucar:udunits:4.5.5")
 }
 
 test {


### PR DESCRIPTION
`bufr` was originally introduced in https://github.com/ome/openmicroscoapy/commit/55e8f4148285cc7ffe2069d1a0fe37617786e447#diff-b114ad382338bb8b3dc78210ff7ce56996f7b3dda03d1e5be6ca79da8660d1aa and was initially part of the importer code

`udunits` was introduced as part of the extraction of the `omero-model` and the migration to the Gradle build system in https://github.com/ome/omero-model/commit/df160f975676c067666aa30cdd3679bc7b197ff4

I could not find any compile requirement for either dependency across the codebase. At runtime, the only requirement I could think of would be HDF-based file formats using the NetCDF-Java library i.e. Minc, Veeco & Imaris HDF. In terms of functional testing, representative samples of each format should be imported into OMERO.server and both the pixeldata and the metadata should be read as expected.