### PR TITLE
Bump Bio-Formats to the latest 8.2.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     api("org.dom4j:dom4j:2.1.4")
 
     // Our libraries
-    api("ome:formats-gpl:8.1.1")
+    api("ome:formats-gpl:8.2.0")
 
     // Unidata
     api("edu.ucar:bufr:3.0"){


### PR DESCRIPTION
See https://www.openmicroscopy.org/2025/05/28/bio-formats-8-2-0.html

All nightly CI integration tests should keep passing with this change included.
Functionally, this should make it possible to import JDCE plates (see https://downloads.openmicroscopy.org/images/JDCE/ for public samples) into OMERO with the new Bio-Formats version.